### PR TITLE
Fixed connection to the db

### DIFF
--- a/Chapter_Three/Lecture_4_Lab/myapp/server.py
+++ b/Chapter_Three/Lecture_4_Lab/myapp/server.py
@@ -14,7 +14,10 @@ class MainHandler(tornado.web.RequestHandler):
 class ProbeHandler(tornado.web.RequestHandler):
     def get(self):
         try:
-            db = pymysql.connect('localhost', 'myapp', 'password', 'myapp')
+            db = pymysql.connect(host='localhost',
+                                 user='myapp',
+                                 password='password',
+                                 database='myapp')
             cursor = db.cursor()
             cursor.execute("SELECT VERSION()")
             result = cursor.fetchone()


### PR DESCRIPTION
pymysql uses keyword arguments on `connect` instead of positional arguments.

Currently pymysql will raise a TypeError exception when attempting to use `connect` with positional arguments. This is fixed by simply passing the arguments with their keywords as defined by [PEP 249][1].


[1]: https://peps.python.org/pep-0249/#id48