### PR TITLE
Update frontend-deployment.yaml (image fix)

### DIFF
--- a/Chapter_Three/Lecture_1_Lab/redisdemo/frontend-deployment.yaml
+++ b/Chapter_Three/Lecture_1_Lab/redisdemo/frontend-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend@sha256:cbc8ef4b0a2d0b95965e0e7dc8938c270ea98e34ec9d60ea64b2d5f2df2dfbbf
+        image: gcr.io/google-samples/gb-frontend:sample-public-image-v5-5be2e51
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Hi, the image was no longer working with the digest written. So I added the tag currently available in that repository, also the next digest might be used. 

gcr.io/google-samples/gb-frontend@sha256:a908df8486ff66f2c4daa0d3d8a2fa09846a1fc8efd65649c0109695c7c5cbff

I hope you accept this update for all the students to be able completing the lab. Thank you in advance and have a nice day.